### PR TITLE
fix(cli): make `kalos init` overwrite safe on non-interactive stdin

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -614,7 +614,9 @@ v1 では、すべてのメトリクスを `raw_value` と `normalized_risk` の
 - **説明**: `kalos init` コマンドで、すべてのルールとデフォルト閾値を含む `.kalos.toml` を生成する
 - **受け入れ基準**:
   - Given プロジェクトディレクトリ, When `kalos init` を実行, Then すべてのルールとデフォルト閾値・設定を含む `.kalos.toml` が生成される
-  - Given `.kalos.toml` が既に存在, When `kalos init` を実行, Then 上書き確認のプロンプトを表示する
+  - Given `.kalos.toml` が既に存在 AND TTY stdin, When `kalos init` を実行, Then 上書き確認のプロンプトを表示する
+  - Given `.kalos.toml` が既に存在 AND `--force` または `--yes`, When `kalos init` を実行, Then プロンプトを出さず上書きする
+  - Given `.kalos.toml` が既に存在 AND 非TTY stdin AND `--force` 未指定, When `kalos init` を実行, Then プロンプトを出さず exit=2 で中断する
 - **優先度**: Should
 - **出典**: ユーザー確認済み
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, BufRead, IsTerminal, Write};
 use std::process::ExitCode;
 
 use clap::Args;
@@ -18,7 +18,16 @@ pub(super) enum GitignoreUpdate {
 
 #[derive(Debug, Clone, Default, Args)]
 #[command(about = "create a default configuration file")]
-pub struct InitCommand {}
+pub struct InitCommand {
+    #[arg(
+        long,
+        short = 'f',
+        visible_alias = "yes",
+        visible_short_alias = 'y',
+        help = "overwrite existing configuration without prompting"
+    )]
+    pub force: bool,
+}
 
 impl InitCommand {
     pub fn execute(&self) -> ExitCode {
@@ -32,21 +41,30 @@ impl InitCommand {
 
         let config_path = cwd.join(CONFIG_FILE_NAME);
         if config_path.exists() {
-            print!("{CONFIG_FILE_NAME} already exists. Overwrite? [y/N] ");
-            if let Err(error) = io::stdout().flush() {
-                eprintln!("failed to flush stdout: {error}");
+            if self.force {
+                // Skip prompting and continue to overwrite below.
+            } else if !io::stdin().is_terminal() {
+                eprintln!(
+                    "{CONFIG_FILE_NAME} already exists; pass --force to overwrite (refusing to prompt on non-interactive stdin)"
+                );
                 return ExitCode::from(2);
-            }
+            } else {
+                let stdin = io::stdin();
+                let mut stdin = stdin.lock();
+                let stdout = io::stdout();
+                let mut stdout = stdout.lock();
+                let confirmed = match confirm_overwrite(&mut stdin, &mut stdout, CONFIG_FILE_NAME) {
+                    Ok(confirmed) => confirmed,
+                    Err(error) => {
+                        eprintln!("failed to confirm overwrite: {error}");
+                        return ExitCode::from(2);
+                    }
+                };
 
-            let mut input = String::new();
-            if let Err(error) = io::stdin().read_line(&mut input) {
-                eprintln!("failed to read overwrite confirmation: {error}");
-                return ExitCode::from(2);
-            }
-
-            if !matches!(input.trim(), "y" | "Y") {
-                println!("aborted");
-                return ExitCode::SUCCESS;
+                if !confirmed {
+                    println!("aborted");
+                    return ExitCode::SUCCESS;
+                }
             }
         }
 
@@ -70,6 +88,19 @@ impl InitCommand {
         }
         ExitCode::SUCCESS
     }
+}
+
+fn confirm_overwrite<R: BufRead, W: Write>(
+    stdin: &mut R,
+    stdout: &mut W,
+    prompt_name: &str,
+) -> io::Result<bool> {
+    write!(stdout, "{prompt_name} already exists. Overwrite? [y/N] ")?;
+    stdout.flush()?;
+
+    let mut input = String::new();
+    stdin.read_line(&mut input)?;
+    Ok(matches!(input.trim(), "y" | "Y"))
 }
 
 pub(super) fn ensure_gitignore_entry(cwd: &std::path::Path) -> io::Result<GitignoreUpdate> {
@@ -101,10 +132,11 @@ pub(super) fn ensure_gitignore_entry(cwd: &std::path::Path) -> io::Result<Gitign
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::io::Cursor;
 
     use tempfile::TempDir;
 
-    use super::{GitignoreUpdate, KALOS_DIR_ENTRY, ensure_gitignore_entry};
+    use super::{GitignoreUpdate, KALOS_DIR_ENTRY, confirm_overwrite, ensure_gitignore_entry};
 
     #[test]
     fn adds_kalos_entry_to_existing_gitignore() {
@@ -172,6 +204,57 @@ mod tests {
         assert_eq!(first, GitignoreUpdate::Added);
         assert_eq!(second, GitignoreUpdate::Unchanged);
         assert_eq!(kalos_entry_count(&contents), 1);
+    }
+
+    #[test]
+    fn confirm_overwrite_accepts_lowercase_y() {
+        let mut stdin = Cursor::new(b"y\n");
+        let mut stdout = Vec::new();
+
+        let confirmed = confirm_overwrite(&mut stdin, &mut stdout, ".kalos.toml").unwrap();
+
+        assert!(confirmed);
+    }
+
+    #[test]
+    fn confirm_overwrite_accepts_uppercase_y() {
+        let mut stdin = Cursor::new(b"Y\n");
+        let mut stdout = Vec::new();
+
+        let confirmed = confirm_overwrite(&mut stdin, &mut stdout, ".kalos.toml").unwrap();
+
+        assert!(confirmed);
+    }
+
+    #[test]
+    fn confirm_overwrite_rejects_n() {
+        let mut stdin = Cursor::new(b"n\n");
+        let mut stdout = Vec::new();
+
+        let confirmed = confirm_overwrite(&mut stdin, &mut stdout, ".kalos.toml").unwrap();
+
+        assert!(!confirmed);
+    }
+
+    #[test]
+    fn confirm_overwrite_rejects_empty_input() {
+        let mut stdin = Cursor::new(b"\n");
+        let mut stdout = Vec::new();
+
+        let confirmed = confirm_overwrite(&mut stdin, &mut stdout, ".kalos.toml").unwrap();
+
+        assert!(!confirmed);
+    }
+
+    #[test]
+    fn confirm_overwrite_writes_prompt_text() {
+        let mut stdin = Cursor::new(b"y\n");
+        let mut stdout = Vec::new();
+
+        confirm_overwrite(&mut stdin, &mut stdout, ".kalos.toml").unwrap();
+
+        let prompt = String::from_utf8(stdout).unwrap();
+        assert!(prompt.contains("already exists. Overwrite? [y/N]"));
     }
 
     fn kalos_entry_count(contents: &str) -> usize {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -197,6 +197,11 @@ mod tests {
         let help = render_help(["kalos", "init", "--help"]);
 
         assert!(help.contains("create a default configuration file"));
+        assert!(help.contains("--force"));
+        assert!(help.contains("-f"));
+        assert!(help.contains("--yes"));
+        assert!(help.contains("-y"));
+        assert!(help.contains("overwrite existing configuration without prompting"));
     }
 
     fn render_help<const N: usize>(args: [&str; N]) -> String {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -65,7 +65,7 @@ fn kalos_init_config_excludes_internal_milestone_terms() {
 }
 
 #[test]
-fn kalos_init_preserves_existing_config_when_declined() {
+fn kalos_init_refuses_overwrite_on_non_tty_stdin_without_force() {
     let temp = TempDir::new().unwrap();
     let config_path = temp.path().join(".kalos.toml");
     fs::write(&config_path, "existing = true\n").unwrap();
@@ -76,8 +76,11 @@ fn kalos_init_preserves_existing_config_when_declined() {
         .write_stdin(b"n\n")
         .arg("init")
         .assert()
-        .success()
-        .stdout(predicate::str::contains("already exists"));
+        .code(2)
+        .stdout(predicate::str::contains("Overwrite?").not())
+        .stderr(predicate::str::contains(
+            ".kalos.toml already exists; pass --force to overwrite (refusing to prompt on non-interactive stdin)",
+        ));
 
     assert_eq!(
         fs::read_to_string(config_path).unwrap(),
@@ -86,7 +89,7 @@ fn kalos_init_preserves_existing_config_when_declined() {
 }
 
 #[test]
-fn kalos_init_overwrites_existing_config_when_confirmed() {
+fn kalos_init_overwrites_existing_config_when_force_flag_is_set() {
     let temp = TempDir::new().unwrap();
     let config_path = temp.path().join(".kalos.toml");
     fs::write(&config_path, "existing = true\n").unwrap();
@@ -94,8 +97,7 @@ fn kalos_init_overwrites_existing_config_when_confirmed() {
     Command::cargo_bin("kalos")
         .unwrap()
         .current_dir(temp.path())
-        .write_stdin(b"y\n")
-        .arg("init")
+        .args(["init", "-f"])
         .assert()
         .success()
         .stdout(predicate::str::contains("created"));
@@ -106,7 +108,7 @@ fn kalos_init_overwrites_existing_config_when_confirmed() {
 }
 
 #[test]
-fn kalos_init_overwrites_existing_config_when_confirmed_with_uppercase_y() {
+fn kalos_init_overwrites_existing_config_when_yes_alias_is_used() {
     let temp = TempDir::new().unwrap();
     let config_path = temp.path().join(".kalos.toml");
     fs::write(&config_path, "existing = true\n").unwrap();
@@ -114,8 +116,7 @@ fn kalos_init_overwrites_existing_config_when_confirmed_with_uppercase_y() {
     Command::cargo_bin("kalos")
         .unwrap()
         .current_dir(temp.path())
-        .write_stdin(b"Y\n")
-        .arg("init")
+        .args(["init", "--yes"])
         .assert()
         .success()
         .stdout(predicate::str::contains("created"));
@@ -183,27 +184,6 @@ fn kalos_init_skips_gitignore_when_kalos_entry_exists() {
     let gitignore = fs::read_to_string(gitignore_path).unwrap();
     assert_eq!(gitignore, "target/\n.kalos/\n");
     assert_eq!(gitignore.matches(".kalos/").count(), 1);
-}
-
-#[test]
-fn kalos_init_preserves_existing_config_on_empty_input() {
-    let temp = TempDir::new().unwrap();
-    let config_path = temp.path().join(".kalos.toml");
-    fs::write(&config_path, "existing = true\n").unwrap();
-
-    Command::cargo_bin("kalos")
-        .unwrap()
-        .current_dir(temp.path())
-        .write_stdin(b"\n")
-        .arg("init")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("aborted"));
-
-    assert_eq!(
-        fs::read_to_string(config_path).unwrap(),
-        "existing = true\n"
-    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #60