### PR TITLE
release: develop -> main (2026-04-19)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,7 +6,7 @@
 
 repository:
   allow_squash_merge: true
-  allow_merge_commit: false
+  allow_merge_commit: true
   allow_rebase_merge: true
   delete_branch_on_merge: true
   allow_update_branch: true
@@ -43,19 +43,9 @@ labels:
     color: ffffff
     description: This will not be worked on
 
-branches:
-  - name: main
-    protection:
-      # Solo maintainer repo — keep review enforcement off so the owner can
-      # still merge without requiring another reviewer. Switch to a non-null
-      # value once a second collaborator joins.
-      required_pull_request_reviews: null
-      required_status_checks:
-        strict: true
-        # Populate with exact workflow job names once CI job contexts are
-        # stable (e.g. "rust", "determinism"). Leave empty for now so the
-        # rule does not block merges before Probot first applies it.
-        contexts: []
-      enforce_admins: false
-      required_linear_history: true
-      restrictions: null
+# Branch protection is managed via GitHub Rulesets (`main-protection`),
+# not by this Probot settings file. The repository-wide ruleset is
+# canonically defined in agentic-workspace at:
+#   .github-templates/rulesets/main-protection.json
+# and applied via:
+#   ./scripts/apply-ruleset.sh <owner/repo>

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -17,7 +17,17 @@ pub(super) enum GitignoreUpdate {
 }
 
 #[derive(Debug, Clone, Default, Args)]
-#[command(about = "create a default configuration file")]
+#[command(
+    about = "create a default configuration file",
+    long_about = "create a default configuration file.\n\
+                  \n\
+                  writes a default .kalos.toml to the current directory and ensures \
+                  .gitignore contains a .kalos/ entry, creating .gitignore if absent. \
+                  if .kalos.toml already exists, prompts for confirmation before overwriting \
+                  on interactive stdin; any response other than `y` or `Y` preserves the \
+                  existing file. pass --force (aliases -f, --yes, -y) to overwrite without \
+                  prompting, which is also required on non-interactive stdin."
+)]
 pub struct InitCommand {
     #[arg(
         long,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -227,6 +227,10 @@ mod tests {
         assert!(help.contains("--yes"));
         assert!(help.contains("-y"));
         assert!(help.contains("overwrite existing configuration without prompting"));
+        assert!(help.contains(".kalos.toml"));
+        assert!(help.contains(".gitignore"));
+        assert!(help.contains(".kalos/"));
+        assert!(help.to_lowercase().contains("overwrit"));
     }
 
     #[test]


### PR DESCRIPTION
## リリース内容

- chore(settings): manage main protection via Rulesets, allow merge commits

This is the first release that flows through the new `develop -> main` flow.