### PR TITLE
fix(cli): support external check cache directory

### DIFF
--- a/src/adapters/extractor/codeql_adapter.rs
+++ b/src/adapters/extractor/codeql_adapter.rs
@@ -163,6 +163,7 @@ pub struct CodeQlAdapter<F, R, T> {
     progress: bool,
     is_emulated: bool,
     min_language_ratio: f64,
+    database_root: Option<PathBuf>,
 }
 
 impl<F, R, T> CodeQlAdapter<F, R, T> {
@@ -183,6 +184,7 @@ impl<F, R, T> CodeQlAdapter<F, R, T> {
             progress: false,
             is_emulated: false,
             min_language_ratio: DEFAULT_MIN_LANGUAGE_RATIO,
+            database_root: None,
         }
     }
 
@@ -198,6 +200,11 @@ impl<F, R, T> CodeQlAdapter<F, R, T> {
 
     pub fn with_min_language_ratio(mut self, ratio: f64) -> Self {
         self.min_language_ratio = ratio;
+        self
+    }
+
+    pub fn with_database_root(mut self, database_root: impl Into<PathBuf>) -> Self {
+        self.database_root = Some(database_root.into());
         self
     }
 
@@ -329,11 +336,7 @@ where
             if self.progress {
                 eprintln!("  codeql: analyzing {} ...", language_name(language));
             }
-            let database_path = request
-                .workspace_root
-                .join(".kalos")
-                .join("codeql")
-                .join(&lang_dir);
+            let database_path = self.database_root(&request.workspace_root).join(&lang_dir);
             let cache_key_path = database_path.with_extension("cache_key");
             let decoded_cache_path = database_path.with_extension("decoded.json");
             let bqrs_path = database_path.with_extension("bqrs");
@@ -537,6 +540,14 @@ where
         }
         analysis.warnings.extend(language_warnings);
         Ok(analysis)
+    }
+}
+
+impl<F, R, T> CodeQlAdapter<F, R, T> {
+    fn database_root(&self, workspace_root: &Path) -> PathBuf {
+        self.database_root
+            .clone()
+            .unwrap_or_else(|| workspace_root.join(".kalos").join("codeql"))
     }
 }
 
@@ -1127,6 +1138,61 @@ mod tests {
                 .created_dirs()
                 .contains(&PathBuf::from("/workspace/.kalos/codeql"))
         );
+    }
+
+    #[test]
+    fn codeql_adapter_uses_external_database_root_when_configured() {
+        let mut file_system = InMemoryFileSystem::new();
+        file_system.insert("/workspace/src/app.py", "def main():\n    return 1\n");
+        let file_system_for_assertion = file_system.clone();
+        let command_runner = MockCommandRunner::new();
+        command_runner
+            .push_result(Ok(ProcessOutput {
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+                exit_code: 0,
+            }))
+            .unwrap();
+        command_runner
+            .push_result(Ok(ProcessOutput {
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+                exit_code: 0,
+            }))
+            .unwrap();
+        command_runner
+            .push_result(Ok(ProcessOutput {
+                stdout: b"{}".to_vec(),
+                stderr: Vec::new(),
+                exit_code: 0,
+            }))
+            .unwrap();
+        let adapter = CodeQlAdapter::new(
+            file_system,
+            command_runner,
+            MockToolCachePort {
+                bundle: ResolvedToolBundle {
+                    tool_name: "codeql".to_owned(),
+                    version: "2.0.0".to_owned(),
+                    cache_path: PathBuf::from("/cache/codeql/2.0.0"),
+                    checksum: "a".repeat(64),
+                },
+            },
+            "2.0.0",
+            Vec::new(),
+        )
+        .with_database_root("/external/kalos-cache/codeql/databases");
+
+        adapter
+            .extract(&ExtractionRequest {
+                workspace_root: PathBuf::from("/workspace"),
+                analysis_targets: vec![FilePath::from(".")],
+            })
+            .unwrap();
+
+        let created_dirs = file_system_for_assertion.created_dirs();
+        assert!(created_dirs.contains(&PathBuf::from("/external/kalos-cache/codeql/databases")));
+        assert!(!created_dirs.contains(&PathBuf::from("/workspace/.kalos/codeql")));
     }
 
     #[test]

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -42,8 +42,10 @@ use crate::ports::PluginPort;
 #[command(
     about = "run code quality analysis",
     after_help = "NOTE: Normal `check` execution may write to locations such as:\n  \
-                  - `<repo>/.kalos/codeql/<language>/` stores per-language CodeQL databases.\n  \
-                  - `$KALOS_CACHE_DIR/baselines/` may store cached baselines for full-workspace runs in Git repositories.\n  \
+                  - `<repo>/.kalos/codeql/<language>/` stores per-language CodeQL databases unless --cache-dir is passed.\n  \
+                  - `$KALOS_CACHE_DIR/codeql/` or `--cache-dir <path>/codeql/` may store managed CodeQL bundles.\n  \
+                  - `$KALOS_CACHE_DIR/baselines/` or `--cache-dir <path>/baselines/` may store cached baselines for full-workspace runs in Git repositories.\n  \
+                  - `--cache-dir <path>/codeql/databases/<language>/` stores per-language CodeQL databases when --cache-dir is passed.\n  \
                   - `<repo>/.gitignore` is only created or updated when --update-gitignore is passed.\n\n\
                   NOTE: On Apple Silicon (aarch64), CodeQL runs via Rosetta 2 using an x86_64 bundle, \
                   which may cause significantly slower analysis on first invocation."
@@ -69,6 +71,12 @@ pub struct CheckCommand {
         help = "path to configuration file (.kalos.toml)"
     )]
     pub config: Option<PathBuf>,
+    #[arg(
+        long,
+        value_name = "path",
+        help = "store managed bundles, baselines, and CodeQL databases under this cache directory"
+    )]
+    pub cache_dir: Option<PathBuf>,
     #[arg(
         long,
         value_name = "path",
@@ -257,7 +265,10 @@ impl CheckCommand {
             }
         }
         let codeql_version = manifest.version.clone();
-        let tool_cache = ManagedToolCacheAdapter::new(manifest);
+        let tool_cache = match &self.cache_dir {
+            Some(cache_dir) => ManagedToolCacheAdapter::with_cache_dir(manifest, cache_dir.clone()),
+            None => ManagedToolCacheAdapter::new(manifest),
+        };
         let exclude_patterns = config
             .exclude_patterns
             .iter()
@@ -270,6 +281,9 @@ impl CheckCommand {
             codeql_version,
             exclude_patterns,
         );
+        if let Some(cache_dir) = &self.cache_dir {
+            extractor = extractor.with_database_root(cache_dir.join("codeql").join("databases"));
+        }
         if self.format == OutputFormat::Human {
             extractor = extractor.with_progress();
         }
@@ -308,7 +322,7 @@ impl CheckCommand {
         );
 
         let result = if let Some(base_ref) = &self.diff {
-            let cache = match BaselineCacheAdapter::new() {
+            let cache = match baseline_cache_adapter(self.cache_dir.as_ref()) {
                 Ok(cache) => cache,
                 Err(error) => {
                     let message = error.to_string();
@@ -350,10 +364,12 @@ impl CheckCommand {
                 }
             }
         } else {
-            let baseline_result = BaselineCacheAdapter::new().ok().and_then(|cache| {
-                let head_tree_hash = resolve_head_tree_hash(&config.workspace_root.abs_path)?;
-                Some((cache, head_tree_hash))
-            });
+            let baseline_result = baseline_cache_adapter(self.cache_dir.as_ref())
+                .ok()
+                .and_then(|cache| {
+                    let head_tree_hash = resolve_head_tree_hash(&config.workspace_root.abs_path)?;
+                    Some((cache, head_tree_hash))
+                });
 
             let run_result = if let Some((cache, head_tree_hash)) = baseline_result.as_ref() {
                 pipeline.run_full_workspace(
@@ -440,12 +456,14 @@ impl CheckCommand {
                 return ExitCode::from(2);
             }
 
-            handle_gitignore_policy(
-                self.update_gitignore,
-                &config.workspace_root.abs_path,
-                result.report.metadata.file_count,
-                self.format == OutputFormat::Human,
-            );
+            if self.cache_dir.is_none() {
+                handle_gitignore_policy(
+                    self.update_gitignore,
+                    &config.workspace_root.abs_path,
+                    result.report.metadata.file_count,
+                    self.format == OutputFormat::Human,
+                );
+            }
 
             if !self.quiet {
                 let file_count = result.report.metadata.file_count;
@@ -464,16 +482,27 @@ impl CheckCommand {
                 );
             }
         } else {
-            handle_gitignore_policy(
-                self.update_gitignore,
-                &config.workspace_root.abs_path,
-                result.report.metadata.file_count,
-                self.format == OutputFormat::Human,
-            );
+            if self.cache_dir.is_none() {
+                handle_gitignore_policy(
+                    self.update_gitignore,
+                    &config.workspace_root.abs_path,
+                    result.report.metadata.file_count,
+                    self.format == OutputFormat::Human,
+                );
+            }
             println!("{rendered}");
         }
 
         map_exit_code(result.exit_code)
+    }
+}
+
+fn baseline_cache_adapter(
+    cache_dir: Option<&PathBuf>,
+) -> Result<BaselineCacheAdapter, crate::adapters::baseline_cache::CacheError> {
+    match cache_dir {
+        Some(cache_dir) => Ok(BaselineCacheAdapter::with_cache_dir(cache_dir.clone())),
+        None => BaselineCacheAdapter::new(),
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -574,8 +574,10 @@ fn kalos_check_help_mentions_apple_silicon() {
 #[test]
 fn kalos_check_help_documents_filesystem_side_effects() {
     let expected = r#"NOTE: Normal `check` execution may write to locations such as:
-  - `<repo>/.kalos/codeql/<language>/` stores per-language CodeQL databases.
-  - `$KALOS_CACHE_DIR/baselines/` may store cached baselines for full-workspace runs in Git repositories.
+  - `<repo>/.kalos/codeql/<language>/` stores per-language CodeQL databases unless --cache-dir is passed.
+  - `$KALOS_CACHE_DIR/codeql/` or `--cache-dir <path>/codeql/` may store managed CodeQL bundles.
+  - `$KALOS_CACHE_DIR/baselines/` or `--cache-dir <path>/baselines/` may store cached baselines for full-workspace runs in Git repositories.
+  - `--cache-dir <path>/codeql/databases/<language>/` stores per-language CodeQL databases when --cache-dir is passed.
   - `<repo>/.gitignore` is only created or updated when --update-gitignore is passed."#;
 
     Command::cargo_bin("kalos")
@@ -601,6 +603,27 @@ fn kalos_check_succeeds_with_non_empty_output_in_temp_workspace() {
         .stdout(predicate::str::is_empty().not());
 
     assert!(temp.path().join(".kalos/codeql/rust.cache_key").exists());
+}
+
+#[test]
+fn kalos_check_cache_dir_avoids_repo_local_kalos_directory() {
+    let temp = seeded_git_workspace();
+    let external = TempDir::new().unwrap();
+    let cache_dir = seed_fake_codeql_bundle(external.path());
+
+    Command::cargo_bin("kalos")
+        .unwrap()
+        .current_dir(temp.path())
+        .env_remove("KALOS_CACHE_DIR")
+        .args(["check", "--cache-dir"])
+        .arg(&cache_dir)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(".kalos/ is not in .gitignore").not());
+
+    assert!(!temp.path().join(".kalos").exists());
+    assert!(cache_dir.join("codeql/databases/rust.cache_key").exists());
+    assert_eq!(baseline_entry_count(&cache_dir), 1);
 }
 
 #[test]


### PR DESCRIPTION
Closes #98

## Summary
- add --cache-dir to route managed bundles, baselines, and CodeQL databases outside the repo
- skip repo-local .kalos gitignore policy when an external cache directory is used
- cover external database root behavior in CLI and adapter tests

## Tests
- git diff --check
- cargo test --test cli
- cargo test codeql_adapter_uses_external_database_root_when_configured