### PR TITLE
fix(cli): classify CodeQL tool errors

### DIFF
--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -692,8 +692,10 @@ fn emit_error(
     match format {
         OutputFormat::Human => eprintln!("{message}"),
         OutputFormat::Json => {
+            let error_class = classify_error(message, source);
             let mut payload = json!({
                 "error": true,
+                "error_class": error_class,
                 "message": message,
             });
             if let Some(source) = source {
@@ -710,11 +712,13 @@ fn emit_error(
         }
         OutputFormat::Sarif => {
             let cause = source.map(|source| source.to_string());
+            let error_class = classify_error(message, source);
             let document = render_sarif_error_document(
                 message,
                 cause.as_deref(),
                 env!("CARGO_PKG_VERSION"),
                 SARIF_TOOL_ERROR_EXIT_CODE,
+                error_class,
             );
             if let Some(path) = output {
                 if write_error_output_file(path, &document) {
@@ -724,6 +728,26 @@ fn emit_error(
 
             println!("{document}");
         }
+    }
+}
+
+fn classify_error(
+    message: &str,
+    source: Option<&(dyn std::error::Error + 'static)>,
+) -> &'static str {
+    let cause = source.map(|source| source.to_string()).unwrap_or_default();
+    let text = format!("{message}\n{cause}");
+
+    if text.contains("failed to resolve CodeQL bundle")
+        || text.contains("CodeQL bundle bootstrap lock")
+        || text.contains("managed CodeQL cache")
+        || text.contains("failed to extract CodeQL bundle")
+    {
+        "codeql_infrastructure"
+    } else if text.contains("CodeQL `") || text.contains("failed to execute `") {
+        "codeql_extraction"
+    } else {
+        "tool_error"
     }
 }
 
@@ -849,5 +873,31 @@ impl From<MinimumSeverity> for Severity {
             MinimumSeverity::Warning => Severity::Warning,
             MinimumSeverity::Info => Severity::Info,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_error;
+
+    #[test]
+    fn classify_error_marks_codeql_bundle_cache_lock_as_infrastructure() {
+        let message = "failed to resolve CodeQL bundle: failed to extract CodeQL bundle v2.25.1";
+        let source = std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            "CodeQL bundle bootstrap lock `/cache/codeql/.codeql-bundle-2.25.1.lock.d` showed no progress for 30000ms; remove the stale lock directory and retry",
+        );
+
+        assert_eq!(
+            classify_error(message, Some(&source)),
+            "codeql_infrastructure"
+        );
+    }
+
+    #[test]
+    fn classify_error_marks_codeql_command_failures_as_extraction() {
+        let message = "CodeQL `query run` failed for `rust` (exit code 2)";
+
+        assert_eq!(classify_error(message, None), "codeql_extraction");
     }
 }

--- a/src/domains/reporting/mod.rs
+++ b/src/domains/reporting/mod.rs
@@ -754,17 +754,20 @@ pub fn render_sarif_error_document(
     cause: Option<&str>,
     tool_version: &str,
     exit_code: i64,
+    error_class: &str,
 ) -> String {
     let mut notification = json!({
         "level": "error",
         "message": { "text": message },
+        "properties": { "error_class": error_class },
     });
     if let Some(cause) = cause {
-        notification["properties"] = json!({ "cause": cause });
+        notification["properties"]["cause"] = json!(cause);
     }
 
     let mut kalos_properties = json!({
         "error": true,
+        "error_class": error_class,
         "message": message,
     });
     if let Some(cause) = cause {
@@ -785,7 +788,7 @@ pub fn render_sarif_error_document(
             "invocations": [{
                 "executionSuccessful": false,
                 "exitCode": exit_code,
-                "exitCodeDescription": "tool error",
+                "exitCodeDescription": error_class_description(error_class),
                 "toolExecutionNotifications": [notification],
             }],
             "results": [],
@@ -796,6 +799,14 @@ pub fn render_sarif_error_document(
     });
 
     serde_json::to_string_pretty(&document).expect("SARIF error document should serialize")
+}
+
+fn error_class_description(error_class: &str) -> &'static str {
+    match error_class {
+        "codeql_infrastructure" => "CodeQL infrastructure error",
+        "codeql_extraction" => "CodeQL extraction error",
+        _ => "tool error",
+    }
 }
 
 pub fn project_metrics(
@@ -2176,6 +2187,7 @@ mod tests {
             Some("No such file or directory (os error 2)"),
             "9.9.9",
             2,
+            "tool_error",
         );
         let parsed: Value = serde_json::from_str(&rendered).expect("sarif error should parse");
 
@@ -2210,9 +2222,11 @@ mod tests {
             notification["properties"]["cause"],
             "No such file or directory (os error 2)"
         );
+        assert_eq!(notification["properties"]["error_class"], "tool_error");
 
         let kalos_props = &run["properties"]["kalos"];
         assert_eq!(kalos_props["error"], Value::Bool(true));
+        assert_eq!(kalos_props["error_class"], "tool_error");
         assert_eq!(kalos_props["message"], "failed to load config file");
         assert!(
             kalos_props["evaluation_artifact"].is_null(),
@@ -2226,15 +2240,41 @@ mod tests {
 
     #[test]
     fn sarif_error_document_omits_cause_when_source_missing() {
-        let rendered = render_sarif_error_document("boom", None, "9.9.9", 2);
+        let rendered = render_sarif_error_document("boom", None, "9.9.9", 2, "tool_error");
         let parsed: Value = serde_json::from_str(&rendered).expect("sarif error should parse");
 
         let notification = &parsed["runs"][0]["invocations"][0]["toolExecutionNotifications"][0];
-        assert!(
-            notification["properties"].is_null() || notification["properties"]["cause"].is_null()
-        );
+        assert!(notification["properties"]["cause"].is_null());
+        assert_eq!(notification["properties"]["error_class"], "tool_error");
         let kalos_props = &parsed["runs"][0]["properties"]["kalos"];
         assert!(kalos_props.get("cause").is_none() || kalos_props["cause"].is_null());
+        assert_eq!(kalos_props["error_class"], "tool_error");
+    }
+
+    #[test]
+    fn sarif_error_document_describes_codeql_infrastructure_error_class() {
+        let rendered = render_sarif_error_document(
+            "failed to resolve CodeQL bundle",
+            Some("CodeQL bundle bootstrap lock showed no progress"),
+            "9.9.9",
+            2,
+            "codeql_infrastructure",
+        );
+        let parsed: Value = serde_json::from_str(&rendered).expect("sarif error should parse");
+
+        let invocation = &parsed["runs"][0]["invocations"][0];
+        assert_eq!(
+            invocation["exitCodeDescription"],
+            "CodeQL infrastructure error"
+        );
+        assert_eq!(
+            invocation["toolExecutionNotifications"][0]["properties"]["error_class"],
+            "codeql_infrastructure"
+        );
+        assert_eq!(
+            parsed["runs"][0]["properties"]["kalos"]["error_class"],
+            "codeql_infrastructure"
+        );
     }
 
     #[test]

--- a/tests/check_runtime.rs
+++ b/tests/check_runtime.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use serde_json::Value;
 use tempfile::TempDir;
 
 use kalos::adapters::dependency_resolver::StubDependencyResolver;
@@ -145,6 +146,35 @@ fn managed_tool_cache_checksum_mismatch_exits_with_code_2_and_clear_error() {
     assert_eq!(
         fs::read_to_string(gitignore_path).unwrap(),
         original_contents
+    );
+}
+
+#[test]
+fn managed_tool_cache_checksum_mismatch_json_reports_infrastructure_error_class() {
+    let temp = seeded_workspace();
+    let cache_dir = seed_invalid_managed_bundle(temp.path());
+
+    let assert = Command::cargo_bin("kalos")
+        .unwrap()
+        .current_dir(temp.path())
+        .env("KALOS_CACHE_DIR", &cache_dir)
+        .args(["check", "--format", "json"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::is_empty());
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let parsed: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["error"], Value::Bool(true));
+    assert_eq!(
+        parsed["error_class"],
+        Value::String("codeql_infrastructure".to_owned())
+    );
+    assert!(
+        parsed["message"]
+            .as_str()
+            .unwrap()
+            .contains("failed to resolve CodeQL bundle")
     );
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1165,6 +1165,10 @@ fn kalos_check_json_output_file_receives_late_codeql_failure() {
     let parsed: Value =
         serde_json::from_str(&rendered).expect("JSON failure output file should parse as JSON");
     assert_eq!(parsed["error"], Value::Bool(true));
+    assert_eq!(
+        parsed["error_class"],
+        Value::String("codeql_extraction".to_owned())
+    );
     assert!(
         parsed["message"]
             .as_str()


### PR DESCRIPTION
## Summary
- add machine-readable error_class to JSON/SARIF tool-error outputs
- classify CodeQL infrastructure and extraction failures separately
- cover the classifications with CLI/runtime/reporting tests

## Tests
- cargo fmt --check
- git diff --check
- cargo test

Closes #159