### PR TITLE
fix: bound managed CodeQL bundle setup

### DIFF
--- a/src/adapters/tool_cache/managed_bundle.rs
+++ b/src/adapters/tool_cache/managed_bundle.rs
@@ -844,6 +844,7 @@ pub fn codeql_bundle_manifest() -> Result<BundleManifest, ManagedToolCacheError>
 pub struct ManagedToolCacheAdapter {
     manifest: BundleManifest,
     cache_dir: Option<PathBuf>,
+    bundle_setup_timeout: Duration,
 }
 
 #[derive(Debug)]
@@ -863,12 +864,14 @@ impl BundleBootstrapLock {
         bundle_root: &Path,
         version: &str,
         deadline: Instant,
+        setup_timeout: Duration,
     ) -> Result<Self, ManagedToolCacheError> {
         Self::acquire_with_timeout_before(
             bundle_root,
             version,
             BUNDLE_BOOTSTRAP_LOCK_TIMEOUT,
             deadline,
+            setup_timeout,
         )
     }
 
@@ -883,6 +886,7 @@ impl BundleBootstrapLock {
             version,
             timeout,
             Instant::now() + BUNDLE_SETUP_TIMEOUT,
+            BUNDLE_SETUP_TIMEOUT,
         )
     }
 
@@ -891,6 +895,7 @@ impl BundleBootstrapLock {
         version: &str,
         timeout: Duration,
         deadline: Instant,
+        setup_timeout: Duration,
     ) -> Result<Self, ManagedToolCacheError> {
         let lock_path = bundle_root.join(format!(".codeql-bundle-{version}.lock.d"));
         loop {
@@ -934,15 +939,19 @@ impl BundleBootstrapLock {
                         }
                         BootstrapLockState::Active | BootstrapLockState::Missing => {}
                     }
-                    let remaining = remaining_bundle_setup_timeout(deadline, "bootstrap lock wait")
-                        .map_err(|source| {
-                            bootstrap_lock_wait_timeout_error(
-                                version.to_owned(),
-                                bundle_root,
-                                &lock_path,
-                                source,
-                            )
-                        })?;
+                    let remaining = remaining_bundle_setup_timeout(
+                        deadline,
+                        setup_timeout,
+                        "bootstrap lock wait",
+                    )
+                    .map_err(|source| {
+                        bootstrap_lock_wait_timeout_error(
+                            version.to_owned(),
+                            bundle_root,
+                            &lock_path,
+                            source,
+                        )
+                    })?;
                     std::thread::sleep(remaining.min(BUNDLE_BOOTSTRAP_LOCK_POLL_INTERVAL));
                 }
                 Err(source) => {
@@ -1032,6 +1041,7 @@ impl ManagedToolCacheAdapter {
         Self {
             manifest,
             cache_dir: None,
+            bundle_setup_timeout: BUNDLE_SETUP_TIMEOUT,
         }
     }
 
@@ -1039,7 +1049,13 @@ impl ManagedToolCacheAdapter {
         Self {
             manifest,
             cache_dir: Some(cache_dir.into()),
+            bundle_setup_timeout: BUNDLE_SETUP_TIMEOUT,
         }
+    }
+
+    pub fn with_bundle_setup_timeout(mut self, timeout: Duration) -> Self {
+        self.bundle_setup_timeout = timeout;
+        self
     }
 
     fn cache_dir(&self) -> PathBuf {
@@ -1051,7 +1067,7 @@ impl ManagedToolCacheAdapter {
     }
 
     fn bootstrap_bundle(&self, bundle_dir: &Path) -> Result<(), ManagedToolCacheError> {
-        let setup_deadline = Instant::now() + BUNDLE_SETUP_TIMEOUT;
+        let setup_deadline = Instant::now() + self.bundle_setup_timeout;
         let bundle_root = bundle_dir.parent().ok_or_else(|| {
             bootstrap_extract_error(
                 self.manifest.version.clone(),
@@ -1066,6 +1082,7 @@ impl ManagedToolCacheAdapter {
             bundle_root,
             &self.manifest.version,
             setup_deadline,
+            self.bundle_setup_timeout,
         )?;
         if self.bundle_marker_matches_manifest(bundle_dir)? {
             return Ok(());
@@ -1125,7 +1142,12 @@ impl ManagedToolCacheAdapter {
         let archive = File::open(archive_path).map_err(|source| {
             bootstrap_extract_error(self.manifest.version.clone(), Some(cache_dir), source)
         })?;
-        let mut archive = DeadlineReader::new(archive, deadline, "cached archive checksum");
+        let mut archive = DeadlineReader::new(
+            archive,
+            deadline,
+            self.bundle_setup_timeout,
+            "cached archive checksum",
+        );
         let mut hasher = Sha256::new();
         let mut buffer = [0_u8; 16 * 1024];
         loop {
@@ -1163,14 +1185,20 @@ impl ManagedToolCacheAdapter {
         archive_path: &Path,
         deadline: Instant,
     ) -> Result<(), ManagedToolCacheError> {
-        let timeout =
-            remaining_bundle_setup_timeout(deadline, "download phase").map_err(|source| {
-                bootstrap_extract_error(
+        let timeout = match remaining_bundle_setup_timeout(
+            deadline,
+            self.bundle_setup_timeout,
+            "download phase",
+        ) {
+            Ok(timeout) => timeout,
+            Err(source) => {
+                return Err(bootstrap_extract_error(
                     self.manifest.version.clone(),
                     archive_path.parent(),
                     source,
-                )
-            })?;
+                ));
+            }
+        };
         let agent = ureq::Agent::config_builder()
             .timeout_connect(Some(Duration::from_secs(10)))
             .timeout_recv_body(Some(Duration::from_secs(30).min(timeout)))
@@ -1436,6 +1464,7 @@ impl ManagedToolCacheAdapter {
         let decoder = GzDecoder::new(DeadlineReader::new(
             archive,
             deadline,
+            self.bundle_setup_timeout,
             "extract/install phase",
         ));
         let mut tar = Archive::new(decoder);
@@ -1679,14 +1708,16 @@ fn remove_file_if_exists(path: &Path) -> io::Result<()> {
 struct DeadlineReader<R> {
     inner: R,
     deadline: Instant,
+    setup_timeout: Duration,
     phase: &'static str,
 }
 
 impl<R> DeadlineReader<R> {
-    fn new(inner: R, deadline: Instant, phase: &'static str) -> Self {
+    fn new(inner: R, deadline: Instant, setup_timeout: Duration, phase: &'static str) -> Self {
         Self {
             inner,
             deadline,
+            setup_timeout,
             phase,
         }
     }
@@ -1694,19 +1725,23 @@ impl<R> DeadlineReader<R> {
 
 impl<R: Read> Read for DeadlineReader<R> {
     fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
-        remaining_bundle_setup_timeout(self.deadline, self.phase)?;
+        remaining_bundle_setup_timeout(self.deadline, self.setup_timeout, self.phase)?;
         self.inner.read(buffer)
     }
 }
 
-fn remaining_bundle_setup_timeout(deadline: Instant, phase: &'static str) -> io::Result<Duration> {
+fn remaining_bundle_setup_timeout(
+    deadline: Instant,
+    setup_timeout: Duration,
+    phase: &'static str,
+) -> io::Result<Duration> {
     let now = Instant::now();
     if now >= deadline {
         return Err(io::Error::new(
             io::ErrorKind::TimedOut,
             format!(
                 "CodeQL bundle setup timed out during {phase}; setup timeout is {}",
-                format_duration(BUNDLE_SETUP_TIMEOUT)
+                format_duration(setup_timeout)
             ),
         ));
     }
@@ -2239,6 +2274,7 @@ mod tests {
             "2.0.0",
             Duration::from_secs(30),
             expired_soon,
+            Duration::from_millis(75),
         )
         .unwrap_err();
         drop(holder);

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -153,7 +153,8 @@ Override severity per rule in .kalos.toml under [rules.<rule-id>]."
         value_name = "seconds",
         value_parser = parse_codeql_timeout_secs,
         default_value_t = 240,
-        help = "maximum seconds allowed for each CodeQL subprocess phase (0 disables the internal timeout)"
+        help = "maximum seconds allowed for CodeQL setup and subprocess phases",
+        long_help = "maximum seconds allowed for managed CodeQL bundle setup and each CodeQL subprocess phase.\n\nThe cap also applies while preparing a cold/cache-heavy managed CodeQL bundle. Pass --codeql-timeout 0 to disable subprocess phase timeouts; managed bundle setup keeps its default timeout."
     )]
     pub codeql_timeout: u64,
     #[arg(
@@ -304,6 +305,10 @@ impl CheckCommand {
         let tool_cache = match &self.cache_dir {
             Some(cache_dir) => ManagedToolCacheAdapter::with_cache_dir(manifest, cache_dir.clone()),
             None => ManagedToolCacheAdapter::new(manifest),
+        };
+        let tool_cache = match self.codeql_timeout {
+            0 => tool_cache,
+            seconds => tool_cache.with_bundle_setup_timeout(Duration::from_secs(seconds)),
         };
         let tool_cache = ProgressToolCacheAdapter::new(
             tool_cache,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -627,7 +627,15 @@ fn kalos_check_help_documents_codeql_timeout_option() {
         .assert()
         .success()
         .stdout(predicate::str::contains("--codeql-timeout <seconds>"))
-        .stdout(predicate::str::contains("0 disables the internal timeout"));
+        .stdout(predicate::str::contains(
+            "managed CodeQL bundle setup and each CodeQL subprocess phase",
+        ))
+        .stdout(predicate::str::contains(
+            "cold/cache-heavy managed CodeQL bundle",
+        ))
+        .stdout(predicate::str::contains(
+            "0 to disable subprocess phase timeouts; managed bundle setup keeps its default timeout",
+        ));
 }
 
 #[test]
@@ -1377,6 +1385,35 @@ fn kalos_check_quiet_human_output_file_receives_codeql_timeout_failure() {
         !rendered.contains("error class: codeql_extraction"),
         "human extraction failures should not add an error class line: {rendered}"
     );
+}
+
+#[test]
+fn kalos_check_codeql_timeout_bounds_managed_bundle_setup() {
+    let temp = seeded_workspace();
+    let manifest = codeql_bundle_manifest().unwrap();
+    let cache_dir = temp.path().join(".kalos-test-cache");
+    let lock_dir = cache_dir
+        .join("codeql")
+        .join(format!(".codeql-bundle-{}.lock.d", manifest.version));
+    fs::create_dir_all(&lock_dir).unwrap();
+    fs::write(lock_dir.join("owner"), "pid=999999\n").unwrap();
+    fs::write(lock_dir.join("heartbeat"), "fresh\n").unwrap();
+
+    Command::cargo_bin("kalos")
+        .unwrap()
+        .current_dir(temp.path())
+        .args(["check", "--cache-dir"])
+        .arg(&cache_dir)
+        .args(["--codeql-timeout", "1"])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("setup bundle"))
+        .stderr(predicate::str::contains("bootstrap lock wait"))
+        .stderr(predicate::str::contains("setup timeout is 1.0s"))
+        .stderr(predicate::str::contains(
+            "cold/cache-heavy CodeQL bundle setup",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- bound managed CodeQL bundle setup by the configured CodeQL timeout
- surface timeout/cache-heavy guidance for cold managed bundle setup
- add regression coverage for bounded bundle setup and help text

## Tests
- cargo test

Closes #170