### PR TITLE
fix(cli): explain bounded CodeQL bundle setup

### DIFF
--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -313,6 +313,7 @@ impl CheckCommand {
         let tool_cache = ProgressToolCacheAdapter::new(
             tool_cache,
             self.format == OutputFormat::Human && !self.quiet,
+            (self.codeql_timeout > 0).then(|| Duration::from_secs(self.codeql_timeout)),
         );
         let exclude_patterns = config
             .exclude_patterns
@@ -552,11 +553,16 @@ impl CheckCommand {
 struct ProgressToolCacheAdapter<T> {
     inner: T,
     progress: bool,
+    setup_timeout: Option<Duration>,
 }
 
 impl<T> ProgressToolCacheAdapter<T> {
-    fn new(inner: T, progress: bool) -> Self {
-        Self { inner, progress }
+    fn new(inner: T, progress: bool, setup_timeout: Option<Duration>) -> Self {
+        Self {
+            inner,
+            progress,
+            setup_timeout,
+        }
     }
 }
 
@@ -574,7 +580,13 @@ where
             return self.inner.resolve_bundle(request);
         }
 
-        eprintln!("  codeql: setup bundle ...");
+        match self.setup_timeout {
+            Some(timeout) => eprintln!(
+                "  codeql: setup bundle ... (timeout {}; cold/cache-heavy cache phase)",
+                format_elapsed(timeout)
+            ),
+            None => eprintln!("  codeql: setup bundle ..."),
+        }
         let started = Instant::now();
         let bundle = self.inner.resolve_bundle(request)?;
         eprintln!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1408,11 +1408,47 @@ fn kalos_check_codeql_timeout_bounds_managed_bundle_setup() {
         .assert()
         .code(2)
         .stdout(predicate::str::is_empty())
-        .stderr(predicate::str::contains("setup bundle"))
+        .stderr(predicate::str::contains(
+            "setup bundle ... (timeout 1.0s; cold/cache-heavy cache phase)",
+        ))
         .stderr(predicate::str::contains("bootstrap lock wait"))
         .stderr(predicate::str::contains("setup timeout is 1.0s"))
         .stderr(predicate::str::contains(
             "cold/cache-heavy CodeQL bundle setup",
+        ));
+}
+
+#[test]
+fn kalos_check_project_human_default_reports_bounded_cache_heavy_setup() {
+    let temp = seeded_workspace();
+    let manifest = codeql_bundle_manifest().unwrap();
+    let cache_dir = temp.path().join(".kalos-test-cache");
+    let lock_dir = cache_dir
+        .join("codeql")
+        .join(format!(".codeql-bundle-{}.lock.d", manifest.version));
+    fs::create_dir_all(&lock_dir).unwrap();
+    fs::write(lock_dir.join("owner"), "pid=999999\n").unwrap();
+    fs::write(lock_dir.join("heartbeat"), "fresh\n").unwrap();
+
+    Command::cargo_bin("kalos")
+        .unwrap()
+        .current_dir(temp.path())
+        .args(["check", ".", "--level", "project", "--format", "human"])
+        .args(["--cache-dir"])
+        .arg(&cache_dir)
+        .args(["--codeql-timeout", "1"])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains(
+            "setup bundle ... (timeout 1.0s; cold/cache-heavy cache phase)",
+        ))
+        .stderr(predicate::str::contains("setup timeout is 1.0s"))
+        .stderr(predicate::str::contains(
+            "Timed out during cold/cache-heavy CodeQL bundle setup or extraction",
+        ))
+        .stderr(predicate::str::contains(
+            "error class: codeql_infrastructure",
         ));
 }
 


### PR DESCRIPTION
## Summary
- include the configured CodeQL bundle setup timeout in human progress output
- label bundle setup as a cold/cache-heavy cache phase before bounded waits
- add a regression test for the Issue #171 project/human/default command shape

## Tests
- cargo fmt --check
- cargo test

Closes #171